### PR TITLE
Minor edits to avoid use of pubternal (public-yet-internal) namespaces

### DIFF
--- a/csharp-visualstudio/Functions.Tests/ListLogger.cs
+++ b/csharp-visualstudio/Functions.Tests/ListLogger.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/csharp-visualstudio/Functions.Tests/NullScope.cs
+++ b/csharp-visualstudio/Functions.Tests/NullScope.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Functions.Tests
+{
+    public class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        private NullScope() { }
+
+        public void Dispose() { }
+    }
+}

--- a/csharp-visualstudio/Functions.Tests/TestFactory.cs
+++ b/csharp-visualstudio/Functions.Tests/TestFactory.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
@@ -29,12 +28,13 @@ namespace Functions.Tests
             return qs;
         }
 
-        public static DefaultHttpRequest CreateHttpRequest(string queryStringKey, string queryStringValue)
+        public static HttpRequest CreateHttpRequest(string queryStringKey, string queryStringValue)
         {
-            var request = new DefaultHttpRequest(new DefaultHttpContext())
-            {
-                Query = new QueryCollection(CreateDictionary(queryStringKey, queryStringValue))
-            };
+            var request = new DefaultHttpContext().Request;
+
+            request.QueryString = 
+                QueryString.Create( queryStringKey, queryStringValue );
+
             return request;
         }
 


### PR DESCRIPTION
## Purpose
Namespaces ending with .Internal are not actually intended to be used, in fact they've been removed from AspDotNet 3.1, so I've made a couple very small changes in the solution csharp-visualstudio\FunctionsTesting.sln to avoid them.  For an explanation from docs.microsoft.com, see [..."Pubternal" APIs removed](https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.2-3.1#pubternal-apis-removed)

## Does this introduce a breaking change?

```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[x ] Code style update (formatting, local variables)
[x ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/rdalkire/azure-functions-tests
cd azure-functions-tests
git checkout rdalkire-nixInternalNamespaceRefs
```

* Test the code

```
Run the tests that already exist within the FunctionsTesting solution
```

## What to Check
Verify that the following are valid
* The tests still pass

## Other Information
n/a